### PR TITLE
Fix bug for non sorted SELECT with OFFSET

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,10 +465,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
-name = "md5"
-version = "0.7.0"
+name = "md-5"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "opaque-debug",
+]
 
 [[package]]
 name = "memchr"
@@ -495,7 +500,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
- "socket2",
+ "socket2 0.3.19",
  "winapi",
 ]
 
@@ -642,16 +647,16 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e34ad3dc5c56d036b9418185ee97e14b6766d55c8ccf9dc18302ad4e6371d9"
+checksum = "ff3e0f70d32e20923cabf2df02913be7c1842d4c772db8065c00fcfdd1d1bff3"
 dependencies = [
  "base64",
  "byteorder",
  "bytes",
  "fallible-iterator",
  "hmac",
- "md5",
+ "md-5",
  "memchr",
  "rand 0.8.3",
  "sha2",
@@ -660,9 +665,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493d9d4613b88b12433aa12890e74e74cd93fdc1e08b7c2aed4768aaae8414c"
+checksum = "430f4131e1b7657b0cd9a2b0c3408d77c9a43a042d300b8c77f981dffcc43a2f"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -1007,6 +1012,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc9f82c2bfb06a33dd0dfb44b07ca98fe72df19e681d80c78d05a1bac2138e2"
+checksum = "2d2b1383c7e4fb9a09e292c7c6afb7da54418d53b045f1c1fac7a911411a2b8b"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1134,7 +1149,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "socket2",
+ "socket2 0.4.0",
  "tokio",
  "tokio-util",
 ]
@@ -1221,9 +1236,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,7 +584,7 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pgimporter"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgimporter"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Miguel Rivero <charrinton@gmail.com>"]
 edition = "2018"
 

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -20,7 +20,7 @@ impl TableImporter for CopyImporter {
         let copy_in_query:String = format!("COPY {}.{} FROM STDIN", import_config.schema, import_config.table);
         let mut writer = db_clients.target_client.copy_in(copy_in_query.as_str()).unwrap();
         writer.write_all(&buf).unwrap();
-        writer.finish().unwrap();    
+        writer.finish().unwrap();
     }
 
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -138,8 +138,8 @@ pub fn import_table_from(schema:String, table:String, where_clause:String, trunc
         match get_any_unique_constraint_fields_for_table(&import_config.schema, &import_config.table) {
             Some(order_by) => multi_import::multi_thread_import(&import_config, &order_by, total_rows_to_import),
             None => {
-                println!("INFO: {}.{} doesn't have any UNIQUE constraint to order by. 
-                    Switching to SINGLE Thread import", &import_config.schema, &import_config.table);
+                println!("INFO: {}.{} doesn't have any UNIQUE constraint to order by. Switching to SINGLE Thread import", 
+                    &import_config.schema, &import_config.table);
                 single_import::single_thread_import(&import_config, total_rows_to_import as u64);
             }
         }

--- a/src/db.rs
+++ b/src/db.rs
@@ -93,20 +93,6 @@ pub fn get_any_unique_constraint_fields_for_table(schema:&str, table:&str) -> Op
     }
 }
 
-pub fn get_first_column_from_table(schema:&str, table:&str) -> String {
-    let mut client = match Client::connect(config::get_source_db_url().as_str(), NoTls) {
-        Ok(client) => client,
-        Err(error) => { println!("Couldn't connect to source DB. Error: {}", error);  std::process::exit(1); }
-    };
-
-    let columns = client.query("SELECT column_name 
-        FROM information_schema.columns WHERE table_schema = $1 AND table_name   = $2;", &[&schema, &table]).unwrap();
-
-    let first_column:String = columns[0].try_get(0).unwrap();
-
-    return first_column;
-}
-
 // TODO: Pass here the connection params as a single struct
 pub fn import_table_from(schema:String, table:String, where_clause:String, truncate:bool) {
     // Get some properties from config

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,14 +1,12 @@
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use postgres::{Client, NoTls};
 use std::time::{Instant};
 use std::sync::Arc;
-use std::thread;
 
 use crate::config;
 use crate::config::{CONFIG_PROPERTIES, ImportConfig};
 
-use crate::copy::CopyImporter;
-use crate::query::QueryImporter;
+use crate::single_import;
+use crate::multi_import;
 
 pub struct DBClients {
     pub source_client:Client,
@@ -141,145 +139,31 @@ pub fn import_table_from(schema:String, table:String, where_clause:String, trunc
 
     println!("{} rows to insert in total", total_rows_to_import);
     
-    // Use smart pointers to share the same common Boxed values between all Threads (not needed for unboxed types)
+    // Use smart pointers to share the same common Boxed values between all potential Threads (not needed for unboxed types)
     let import_config = Arc::new(import_config);
 
-    // Check if there's 
-    //match get_any_unique_constraint_fields_for_table(&import_config.schema, &import_config.table) {
-
-    //}
-    let order_by = get_first_column_from_table(&import_config.schema, &import_config.table);
-
-    multi_thread_import(&import_config, &order_by, total_rows_to_import);
+    // If single thread is forced by config, just use it
+    if CONFIG_PROPERTIES.max_threads < 2 {
+        single_import::single_thread_import(&import_config, total_rows_to_import as u64);
+    }
+    else {
+        // Check if there's any UNIQUE constraint in the source table so we can use it for the ORDER BY
+        // If there's none we have to use single-thread version to make import results are correct
+        match get_any_unique_constraint_fields_for_table(&import_config.schema, &import_config.table) {
+            Some(order_by) => multi_import::multi_thread_import(&import_config, &order_by, total_rows_to_import),
+            None => {
+                println!("INFO: {}.{} doesn't have any UNIQUE constraint to order by. 
+                    Switching to SINGLE Thread import", &import_config.schema, &import_config.table);
+                single_import::single_thread_import(&import_config, total_rows_to_import as u64);
+            }
+        }
+    }
 
     let duration = start.elapsed();
     println!("Finished importing {} rows from table {}.{} in {} secs", total_rows_to_import, import_config.schema, 
         import_config.table, duration.as_secs());
 }
 
-fn multi_thread_import(import_config:&Arc<ImportConfig>, order_by:&String, total_rows_to_import:i64) {
-
-    let max_threads = CONFIG_PROPERTIES.max_threads;
-    let max_rows_for_select = CONFIG_PROPERTIES.rows_select;
-
-    // Divide all rows to import by the number of threads to use
-    let rows_per_thread = total_rows_to_import / max_threads;
-
-    // START IMPORTING, SPAWNING WORKER THREADS
-    // Create the progression bars
-    let multi_progress_bar = MultiProgress::new();
-    let sty = ProgressStyle::default_bar()
-        .template("[{elapsed_precise}] {bar:40.cyan/blue} {pos:>7}/{len:7} {msg}")
-        .progress_chars("##-");
-
-    let mut previous_thread_last_row = 0;
-    // Remember that higher limit in for loop is exclusive in Rust so this is actually 0 to max_threads-1:
-    for thread_num in 0..max_threads {
-    
-        let limit_for_this_thread;
-
-        if thread_num == max_threads-1 {
-            // Last thread inserts remaining rows
-            limit_for_this_thread = total_rows_to_import - previous_thread_last_row;
-        }
-        else {
-            limit_for_this_thread = rows_per_thread
-        }
-        
-        // This thread working row starts from previous thread last row
-        let mut offset_for_this_thread = previous_thread_last_row;
-        if thread_num == 0 {
-            offset_for_this_thread = previous_thread_last_row;
-        }
-        
-        // Set last row for this thread (previous_thread for the next thread)
-        previous_thread_last_row = offset_for_this_thread + limit_for_this_thread;
-        
-        // Create a new progress bar to show the progress of this thread
-        let progress_bar = multi_progress_bar.add(ProgressBar::new(limit_for_this_thread as u64));
-        progress_bar.set_style(sty.clone());
-
-        // Clone the smart pointer so each thread has its own references to the DB values
-        // Those references will be removed when the thread ends and when there are no references left the memory will be freed
-        let import_config = import_config.clone();
-        let order_by = order_by.clone();
-
-        // NEW WORKER THREAD BEGINS
-        thread::spawn(move || {
-            
-            let source_client = match Client::connect(import_config.source_db_url.as_ref(), NoTls) {
-                Ok(client) => client,
-                Err(error) => { println!("Couldn't connect to source DB. Error: {}", error);  std::process::exit(1); }
-            };
-            
-            let target_client = match Client::connect(import_config.target_db_url.as_ref(), NoTls) {
-                Ok(client) => client,
-                Err(error) => { println!("Couldn't connect to target DB. Error: {}", error);  std::process::exit(1); }
-            };
-
-            let mut db_clients = DBClients { source_client: source_client, target_client: target_client};
-
-            let mut rows_read_in_this_thread = 0;
-            // Create select query
-            let mut complete_where:String = import_config.where_clause.to_owned().to_string();
-            if !import_config.where_clause.is_empty() {
-                complete_where = format!("WHERE {}", import_config.where_clause);
-            }
-
-            // If number of rows to read in this thread are more than MAX_ROWS_FOR_SELECT, divide in several selects of max size
-            // Doing this is specially important for big queries, as the memory consumption could even kill the process
-            let mut limit = limit_for_this_thread;
-            let mut offset = offset_for_this_thread;
-            let max_offset = offset_for_this_thread + limit_for_this_thread;
-            if limit_for_this_thread > max_rows_for_select {
-                limit = max_rows_for_select;
-            }
-
-            // Show progress bar
-            progress_bar.inc(0 as u64);
-
-            // Iterate until finishing with all rows assigned to this thread
-            while offset < max_offset {
-  
-                let table_chunk = TableChunk { where_clause: complete_where.to_owned(), offset: offset, limit: limit, order_by: order_by.to_owned()};
-
-                if import_config.importer_impl == "QUERY" {
-                    let importer = QueryImporter;                    
-                    importer.import_table_chunk(&import_config, &mut db_clients, &table_chunk);
-                }
-                else {
-                    let importer = CopyImporter;
-                    importer.import_table_chunk(&import_config, &mut db_clients, &table_chunk);
-                }
- 
-                // Update progress bar after execution
-                progress_bar.inc(limit as u64);
-
-                rows_read_in_this_thread = rows_read_in_this_thread + limit;
-
-                // Increase the offset in the same amount as the rows read (limit)
-                // If new offset + limit > max_offset
-                // set the new limit as the difference between max_offset and current new offset
-                offset += limit;
-                if offset + limit > max_offset {
-                    limit = max_offset - offset;
-                }
-            } // THREAD ENDS
-
-            progress_bar.finish_with_message(
-                format!("Thread {} finished reading rows from {} to {}",thread_num, offset_for_this_thread, max_offset).as_str());
-            return limit_for_this_thread;
-        });
-
-    }
-
-    // Wait for all the progress bars to finish. Also acts as a join for the child threads
-    multi_progress_bar.join_and_clear().unwrap();
-}
-
-fn single_thread_import(import_config:&ImportConfig) {
-
-}
 
 fn count_total_rows_for_import(import_config:&ImportConfig) -> i64 {
     let mut count_db_client = match Client::connect(import_config.source_db_url.as_str(), NoTls) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ mod config;
 mod batch;
 mod query;
 mod copy;
+mod single_import;
+mod multi_import;
 
 use dialoguer::{theme::ColorfulTheme, MultiSelect, Select, Input, Confirm};
 use log::LevelFilter;

--- a/src/multi_import.rs
+++ b/src/multi_import.rs
@@ -1,0 +1,129 @@
+use crate::config::{ImportConfig, CONFIG_PROPERTIES};
+use postgres::{Client, NoTls};
+use std::sync::Arc;
+use std::thread;
+use indicatif::{ProgressBar, ProgressStyle, MultiProgress};
+
+use crate::copy::CopyImporter;
+use crate::query::QueryImporter;
+use crate::db::{DBClients, TableChunk, TableImporter};
+
+pub fn multi_thread_import(import_config:&Arc<ImportConfig>, order_by:&String, total_rows_to_import:i64) {
+
+    let max_threads = CONFIG_PROPERTIES.max_threads;
+    let max_rows_for_select = CONFIG_PROPERTIES.rows_select;
+
+    // Divide all rows to import by the number of threads to use
+    let rows_per_thread = total_rows_to_import / max_threads;
+
+    // START IMPORTING, SPAWNING WORKER THREADS
+    // Create the progression bars
+    let multi_progress_bar = MultiProgress::new();
+    let sty = ProgressStyle::default_bar()
+        .template("[{elapsed_precise}] {bar:40.cyan/blue} {pos:>7}/{len:7} {msg}")
+        .progress_chars("##-");
+
+    let mut previous_thread_last_row = 0;
+    // Remember that higher limit in for loop is exclusive in Rust so this is actually 0 to max_threads-1:
+    for thread_num in 0..max_threads {
+    
+        let limit_for_this_thread;
+
+        if thread_num == max_threads-1 {
+            // Last thread inserts remaining rows
+            limit_for_this_thread = total_rows_to_import - previous_thread_last_row;
+        }
+        else {
+            limit_for_this_thread = rows_per_thread
+        }
+        
+        // This thread working row starts from previous thread last row
+        let mut offset_for_this_thread = previous_thread_last_row;
+        if thread_num == 0 {
+            offset_for_this_thread = previous_thread_last_row;
+        }
+        
+        // Set last row for this thread (previous_thread for the next thread)
+        previous_thread_last_row = offset_for_this_thread + limit_for_this_thread;
+        
+        // Create a new progress bar to show the progress of this thread
+        let progress_bar = multi_progress_bar.add(ProgressBar::new(limit_for_this_thread as u64));
+        progress_bar.set_style(sty.clone());
+
+        // Clone the smart pointer so each thread has its own references to the DB values
+        // Those references will be removed when the thread ends and when there are no references left the memory will be freed
+        let import_config = import_config.clone();
+        let order_by = order_by.clone();
+
+        // NEW WORKER THREAD BEGINS
+        thread::spawn(move || {
+            
+            let source_client = match Client::connect(import_config.source_db_url.as_ref(), NoTls) {
+                Ok(client) => client,
+                Err(error) => { println!("Couldn't connect to source DB. Error: {}", error);  std::process::exit(1); }
+            };
+            
+            let target_client = match Client::connect(import_config.target_db_url.as_ref(), NoTls) {
+                Ok(client) => client,
+                Err(error) => { println!("Couldn't connect to target DB. Error: {}", error);  std::process::exit(1); }
+            };
+
+            let mut db_clients = DBClients { source_client: source_client, target_client: target_client};
+
+            let mut rows_read_in_this_thread = 0;
+            // Create select query
+            let mut complete_where:String = import_config.where_clause.to_owned().to_string();
+            if !import_config.where_clause.is_empty() {
+                complete_where = format!("WHERE {}", import_config.where_clause);
+            }
+
+            // If number of rows to read in this thread are more than MAX_ROWS_FOR_SELECT, divide in several selects of max size
+            // Doing this is specially important for big queries, as the memory consumption could even kill the process
+            let mut limit = limit_for_this_thread;
+            let mut offset = offset_for_this_thread;
+            let max_offset = offset_for_this_thread + limit_for_this_thread;
+            if limit_for_this_thread > max_rows_for_select {
+                limit = max_rows_for_select;
+            }
+
+            progress_bar.set_position(0);
+
+            // Iterate until finishing with all rows assigned to this thread
+            while offset < max_offset {
+  
+                let table_chunk = TableChunk { where_clause: complete_where.to_owned(), offset: offset, 
+                    limit: limit, order_by: order_by.to_owned()};
+
+                if import_config.importer_impl == "QUERY" {
+                    let importer = QueryImporter;                    
+                    importer.import_table_chunk(&import_config, &mut db_clients, &table_chunk);
+                }
+                else {
+                    let importer = CopyImporter;
+                    importer.import_table_chunk(&import_config, &mut db_clients, &table_chunk);
+                }
+ 
+                // Update progress bar after execution
+                progress_bar.inc(limit as u64);
+
+                rows_read_in_this_thread = rows_read_in_this_thread + limit;
+
+                // Increase the offset in the same amount as the rows read (limit)
+                // If new offset + limit > max_offset
+                // set the new limit as the difference between max_offset and current new offset
+                offset += limit;
+                if offset + limit > max_offset {
+                    limit = max_offset - offset;
+                }
+            } // THREAD ENDS
+
+            progress_bar.finish_with_message(
+                format!("Thread {} finished reading rows from {} to {}",thread_num, offset_for_this_thread, max_offset).as_str());
+            return limit_for_this_thread;
+        });
+
+    }
+
+    // Wait for all the progress bars to finish. Also acts as a join for the child threads
+    multi_progress_bar.join_and_clear().unwrap();
+}

--- a/src/single_import.rs
+++ b/src/single_import.rs
@@ -16,8 +16,14 @@ pub fn single_thread_import(import_config:&ImportConfig, total_rows_to_import:u6
         Err(error) => { println!("Couldn't connect to target DB. Error: {}", error);  std::process::exit(1); }
     };
 
+    // Create WHERE section of query (if present)
+    let mut complete_where:String = import_config.where_clause.to_owned().to_string();
+    if !import_config.where_clause.is_empty() {
+        complete_where = format!("WHERE {}", import_config.where_clause);
+    }
+
     // Create copy query to extract data
-    let select_query = format!("SELECT * FROM {}.{} {}", import_config.schema, import_config.table, import_config.where_clause);
+    let select_query = format!("SELECT * FROM {}.{} {}", import_config.schema, import_config.table, complete_where);
     let copy_out_query:String = format!("COPY ({}) TO STDOUT", select_query);
     
     let mut reader = source_client.copy_out(copy_out_query.as_str()).unwrap();

--- a/src/single_import.rs
+++ b/src/single_import.rs
@@ -1,0 +1,71 @@
+use std::io::{BufRead, Write};
+use crate::config::{ImportConfig, CONFIG_PROPERTIES};
+use postgres::{Client, NoTls};
+use indicatif::{ProgressBar, ProgressStyle};
+
+pub fn single_thread_import(import_config:&ImportConfig, total_rows_to_import:u64) {
+    let max_rows_per_batch = CONFIG_PROPERTIES.rows_select;
+
+    let mut source_client = match Client::connect(import_config.source_db_url.as_ref(), NoTls) {
+        Ok(client) => client,
+        Err(error) => { println!("Couldn't connect to source DB. Error: {}", error);  std::process::exit(1); }
+    };
+    
+    let mut target_client = match Client::connect(import_config.target_db_url.as_ref(), NoTls) {
+        Ok(client) => client,
+        Err(error) => { println!("Couldn't connect to target DB. Error: {}", error);  std::process::exit(1); }
+    };
+
+    // Create copy query to extract data
+    let select_query = format!("SELECT * FROM {}.{} {}", import_config.schema, import_config.table, import_config.where_clause);
+    let copy_out_query:String = format!("COPY ({}) TO STDOUT", select_query);
+    
+    let mut reader = source_client.copy_out(copy_out_query.as_str()).unwrap();
+
+    // Create ProgressBar to show progress of import to user
+    let pb = ProgressBar::new(total_rows_to_import);
+    let sty = ProgressStyle::default_bar()
+        .template("[{elapsed_precise}] {bar:40.cyan/blue} {pos:>7}/{len:7} {msg}")
+        .progress_chars("##-");
+    pb.set_style(sty);
+    pb.set_position(0);
+
+    let mut buffer = vec!();
+    let mut total_rows = 0;
+    // Keep reading from source until reader is empty
+    loop {
+        let row = reader.fill_buf().unwrap();
+        let row_bytes = row.len();
+        
+        // If we've reached EOF, end now, writing remaining rows on buffer
+        if row_bytes == 0 {
+            if buffer.len() > 0 {
+                write_to_target(import_config, &mut target_client, &buffer);
+                pb.finish_and_clear();
+            }
+            break;
+        }
+    
+        buffer.extend(row);
+        total_rows = total_rows + 1;
+
+        if total_rows % max_rows_per_batch == 0 {
+            write_to_target(import_config, &mut target_client, &buffer);
+            pb.set_position(total_rows as u64);
+            buffer = vec!();
+        }
+
+        // ensure the bytes we worked with aren't returned again later
+        reader.consume(row_bytes);
+    }
+
+    println!("TOTAL ROWS READ: {}", total_rows);
+}
+
+fn write_to_target(import_config:&ImportConfig, target_client:&mut Client, buffer:&[u8]) {
+    // Create copy query to import data
+    let copy_in_query:String = format!("COPY {}.{} FROM STDIN", import_config.schema, import_config.table);
+    let mut writer = target_client.copy_in(copy_in_query.as_str()).unwrap();
+    writer.write_all(&buffer).unwrap();
+    writer.finish().unwrap();
+}


### PR DESCRIPTION
A correct split of a query in several queries using offset and limit can only ensure a correct result if there's a UNIQUE column to order by.

If there's not, the tool switches now automatically to Single Thread mode